### PR TITLE
Avoid using last rt value in for loop for DropResultLabels logic.

### DIFF
--- a/comparer/comparer.go
+++ b/comparer/comparer.go
@@ -111,11 +111,12 @@ func (c *Comparer) Compare(tc *TestCase) (*Result, error) {
 
 	for _, rt := range c.QueryTweaks {
 		if len(rt.DropResultLabels) != 0 {
+			localRt := rt
 			cmpOpts = append(
 				cmpOpts,
 				cmp.Options{cmp.Transformer("DropResultLabels", func(in model.Metric) model.Metric {
 					m := in.Clone()
-					for _, ln := range rt.DropResultLabels {
+					for _, ln := range localRt.DropResultLabels {
 						delete(m, ln)
 					}
 					return m


### PR DESCRIPTION
If there is more than one QueryTweak, the last one processed by the for loop is the one used in the DropResultLabels logic.  

This will create a local reference to the correct QueryTweak instance inside the for loop to be used by the logic.