### PR TITLE
New relic testing support

### DIFF
--- a/cmd/promql-compliance-tester/main.go
+++ b/cmd/promql-compliance-tester/main.go
@@ -34,6 +34,10 @@ type RoundTripperWithHeader struct {
 }
 
 func (rt RoundTripperWithHeader) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Per RoundTrip's documentation, RoundTrip should not modify the request,
+	// except for consuming and closing the Request's Body.
+	// TODO: Update the Go Prometheus client code to support adding headers to request.
+
 	for key, value := range rt.Headers {
 		req.Header.Add(key, value)
 	}

--- a/cmd/promql-compliance-tester/main.go
+++ b/cmd/promql-compliance-tester/main.go
@@ -18,8 +18,8 @@ import (
 
 func newPromAPI(targetConfig config.TargetConfig) (v1.API, error) {
 	apiConfig := api.Config{Address: targetConfig.QueryURL}
-	if len(targetConfig.XQueryKey) > 0 {
-		apiConfig.RoundTripper = RoundTripperWithHeader{XQueryKey: targetConfig.XQueryKey}
+	if len(targetConfig.Headers) > 0 {
+		apiConfig.RoundTripper = RoundTripperWithHeader{targetConfig.Headers}
 	}
 	client, err := api.NewClient(apiConfig)
 	if err != nil {
@@ -30,11 +30,13 @@ func newPromAPI(targetConfig config.TargetConfig) (v1.API, error) {
 }
 
 type RoundTripperWithHeader struct {
-	XQueryKey string
+	Headers map[string]string
 }
 
 func (rt RoundTripperWithHeader) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Add("X-Query-Key", rt.XQueryKey)
+	for key, value := range rt.Headers {
+		req.Header.Add(key, value)
+	}
 	return http.DefaultTransport.RoundTrip(req)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -25,18 +25,13 @@ type TargetConfig struct {
 
 // A QueryTweak restricts or modifies a query in certain ways that avoids certain systematic errors and/or later comparison problems.
 type QueryTweak struct {
-	Note                   string            `yaml:"note" json:"note"`
-	NoBug                  bool              `yaml:"no_bug,omitempty" json:"noBug,omitempty"`
-	TruncateTimestampsToMS int64             `yaml:"truncate_timestamps_to_ms" json:"truncateTimestampsToMS,omitempty"`
-	AlignTimestampsToStep  bool              `yaml:"align_timestamps_to_step" json:"alignTimestampsToStep,omitempty"`
-	DropResultLabels       []model.LabelName `yaml:"drop_result_labels" json:"dropResultLabels,omitempty"`
-	IgnoreFirstStep        bool              `yaml:"ignore_first_step" json:"ignoreFirstStep,omitempty"`
-	ApplyQuerySubstitution Substitution      `yaml:"apply_query_substitution" json:"applyQuerySubstitution,omitempty"`
-}
-
-type Substitution struct {
-	Old string `yaml:"old" json:"old"`
-	New string `yaml:"new" json:"new"`
+	Note                    string            `yaml:"note" json:"note"`
+	NoBug                   bool              `yaml:"no_bug,omitempty" json:"noBug,omitempty"`
+	TruncateTimestampsToMS  int64             `yaml:"truncate_timestamps_to_ms" json:"truncateTimestampsToMS,omitempty"`
+	AlignTimestampsToStep   bool              `yaml:"align_timestamps_to_step" json:"alignTimestampsToStep,omitempty"`
+	DropResultLabels        []model.LabelName `yaml:"drop_result_labels" json:"dropResultLabels,omitempty"`
+	IgnoreFirstStep         bool              `yaml:"ignore_first_step" json:"ignoreFirstStep,omitempty"`
+	QueryStringReplacements map[string]string `yaml:"query_string_replacements" json:"queryStringReplacements,omitempty"`
 }
 
 // TestCase represents a given query (pattern) to be tested.

--- a/config/config.go
+++ b/config/config.go
@@ -18,9 +18,9 @@ type Config struct {
 
 // TargetConfig represents the configuration of a single Prometheus API endpoint.
 type TargetConfig struct {
-	QueryURL  string `yaml:"query_url"`
-	XQueryKey string `yaml:"x_query_key"`
-	TSDBPath  string `yaml:"tsdb_path"`
+	QueryURL string            `yaml:"query_url"`
+	Headers  map[string]string `yaml:"headers"`
+	TSDBPath string            `yaml:"tsdb_path"`
 }
 
 // A QueryTweak restricts or modifies a query in certain ways that avoids certain systematic errors and/or later comparison problems.

--- a/config/config.go
+++ b/config/config.go
@@ -18,8 +18,9 @@ type Config struct {
 
 // TargetConfig represents the configuration of a single Prometheus API endpoint.
 type TargetConfig struct {
-	QueryURL string `yaml:"query_url"`
-	TSDBPath string `yaml:"tsdb_path"`
+	QueryURL  string `yaml:"query_url"`
+	XQueryKey string `yaml:"x_query_key"`
+	TSDBPath  string `yaml:"tsdb_path"`
 }
 
 // A QueryTweak restricts or modifies a query in certain ways that avoids certain systematic errors and/or later comparison problems.

--- a/config/config.go
+++ b/config/config.go
@@ -25,13 +25,13 @@ type TargetConfig struct {
 
 // A QueryTweak restricts or modifies a query in certain ways that avoids certain systematic errors and/or later comparison problems.
 type QueryTweak struct {
-	Note                   string            `yaml:"note" json:"note"`
-	NoBug                  bool              `yaml:"no_bug,omitempty" json:"noBug,omitempty"`
-	TruncateTimestampsToMS int64             `yaml:"truncate_timestamps_to_ms" json:"truncateTimestampsToMS,omitempty"`
-	AlignTimestampsToStep  bool              `yaml:"align_timestamps_to_step" json:"alignTimestampsToStep,omitempty"`
-	DropResultLabels       []model.LabelName `yaml:"drop_result_labels" json:"dropResultLabels,omitempty"`
-	IgnoreFirstStep        bool              `yaml:"ignore_first_step" json:"ignoreFirstStep,omitempty"`
-	ApplyQuerySubstitution Substitution      `yaml:"apply_query_substitution" json:"applyQuerySubstitution,omitempty"`
+	Note                    string            `yaml:"note" json:"note"`
+	NoBug                   bool              `yaml:"no_bug,omitempty" json:"noBug,omitempty"`
+	TruncateTimestampsToMS  int64             `yaml:"truncate_timestamps_to_ms" json:"truncateTimestampsToMS,omitempty"`
+	AlignTimestampsToStep   bool              `yaml:"align_timestamps_to_step" json:"alignTimestampsToStep,omitempty"`
+	DropResultLabels        []model.LabelName `yaml:"drop_result_labels" json:"dropResultLabels,omitempty"`
+	IgnoreFirstStep         bool              `yaml:"ignore_first_step" json:"ignoreFirstStep,omitempty"`
+	QueryStringReplacements Substitution      `yaml:"query_string_replacements" json:"queryStringReplacements,omitempty"`
 }
 
 type Substitution struct {

--- a/config/config.go
+++ b/config/config.go
@@ -25,13 +25,19 @@ type TargetConfig struct {
 
 // A QueryTweak restricts or modifies a query in certain ways that avoids certain systematic errors and/or later comparison problems.
 type QueryTweak struct {
-	Note                    string            `yaml:"note" json:"note"`
-	NoBug                   bool              `yaml:"no_bug,omitempty" json:"noBug,omitempty"`
-	TruncateTimestampsToMS  int64             `yaml:"truncate_timestamps_to_ms" json:"truncateTimestampsToMS,omitempty"`
-	AlignTimestampsToStep   bool              `yaml:"align_timestamps_to_step" json:"alignTimestampsToStep,omitempty"`
-	DropResultLabels        []model.LabelName `yaml:"drop_result_labels" json:"dropResultLabels,omitempty"`
-	IgnoreFirstStep         bool              `yaml:"ignore_first_step" json:"ignoreFirstStep,omitempty"`
-	QueryStringReplacements map[string]string `yaml:"query_string_replacements" json:"queryStringReplacements,omitempty"`
+	Note                   string            `yaml:"note" json:"note"`
+	NoBug                  bool              `yaml:"no_bug,omitempty" json:"noBug,omitempty"`
+	TruncateTimestampsToMS int64             `yaml:"truncate_timestamps_to_ms" json:"truncateTimestampsToMS,omitempty"`
+	AlignTimestampsToStep  bool              `yaml:"align_timestamps_to_step" json:"alignTimestampsToStep,omitempty"`
+	DropResultLabels       []model.LabelName `yaml:"drop_result_labels" json:"dropResultLabels,omitempty"`
+	IgnoreFirstStep        bool              `yaml:"ignore_first_step" json:"ignoreFirstStep,omitempty"`
+	ApplyQuerySubstitution Substitution      `yaml:"apply_query_substitution" json:"applyQuerySubstitution,omitempty"`
+}
+
+type Substitution struct {
+	Remove      string   `yaml:"remove" json:"remove"`
+	Replacement string   `yaml:"replacement" json:"replacement"`
+	Exemptions  []string `yaml:"exemptions" json:"exemptions"`
 }
 
 // TestCase represents a given query (pattern) to be tested.

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,12 @@ type QueryTweak struct {
 	AlignTimestampsToStep  bool              `yaml:"align_timestamps_to_step" json:"alignTimestampsToStep,omitempty"`
 	DropResultLabels       []model.LabelName `yaml:"drop_result_labels" json:"dropResultLabels,omitempty"`
 	IgnoreFirstStep        bool              `yaml:"ignore_first_step" json:"ignoreFirstStep,omitempty"`
+	ApplyQuerySubstitution Substitution      `yaml:"apply_query_substitution" json:"applyQuerySubstitution,omitempty"`
+}
+
+type Substitution struct {
+	Old string `yaml:"old" json:"old"`
+	New string `yaml:"new" json:"new"`
 }
 
 // TestCase represents a given query (pattern) to be tested.

--- a/config/config.go
+++ b/config/config.go
@@ -25,19 +25,12 @@ type TargetConfig struct {
 
 // A QueryTweak restricts or modifies a query in certain ways that avoids certain systematic errors and/or later comparison problems.
 type QueryTweak struct {
-	Note                    string            `yaml:"note" json:"note"`
-	NoBug                   bool              `yaml:"no_bug,omitempty" json:"noBug,omitempty"`
-	TruncateTimestampsToMS  int64             `yaml:"truncate_timestamps_to_ms" json:"truncateTimestampsToMS,omitempty"`
-	AlignTimestampsToStep   bool              `yaml:"align_timestamps_to_step" json:"alignTimestampsToStep,omitempty"`
-	DropResultLabels        []model.LabelName `yaml:"drop_result_labels" json:"dropResultLabels,omitempty"`
-	IgnoreFirstStep         bool              `yaml:"ignore_first_step" json:"ignoreFirstStep,omitempty"`
-	QueryStringReplacements Substitution      `yaml:"query_string_replacements" json:"queryStringReplacements,omitempty"`
-}
-
-type Substitution struct {
-	Remove      string   `yaml:"remove" json:"remove"`
-	Replacement string   `yaml:"replacement" json:"replacement"`
-	Exemptions  []string `yaml:"exemptions" json:"exemptions"`
+	Note                   string            `yaml:"note" json:"note"`
+	NoBug                  bool              `yaml:"no_bug,omitempty" json:"noBug,omitempty"`
+	TruncateTimestampsToMS int64             `yaml:"truncate_timestamps_to_ms" json:"truncateTimestampsToMS,omitempty"`
+	AlignTimestampsToStep  bool              `yaml:"align_timestamps_to_step" json:"alignTimestampsToStep,omitempty"`
+	DropResultLabels       []model.LabelName `yaml:"drop_result_labels" json:"dropResultLabels,omitempty"`
+	IgnoreFirstStep        bool              `yaml:"ignore_first_step" json:"ignoreFirstStep,omitempty"`
 }
 
 // TestCase represents a given query (pattern) to be tested.

--- a/promql-compliance-tester.yml
+++ b/promql-compliance-tester.yml
@@ -13,6 +13,10 @@ test_target_config:
   #
   # UNCOMMENT FOR THANOS:
   # query_url: 'http://localhost:20902'
+  #
+  # UNCOMMENT FOR NEW RELIC, replacing <insights_query_api_key>
+  # query_url: https://prometheus-api.newrelic.com
+  # x_query_key: <insights_query_api_key>
 
 query_tweaks:
   # UNCOMMENT FOR CORTEX:
@@ -30,6 +34,22 @@ query_tweaks:
   # UNCOMMENT FOR VICTORIAMETRICS:
   #- note: 'VictoriaMetrics incorrectly modifies incoming start/end range query timestamps to be aligned to the resolution step size.'
   #  align_timestamps_to_step: true
+  #
+  # UNCOMMENT FOR NEW RELIC:
+  #- note: 'New Relic is sometimes off by 1ms when parsing floating point start/end timestamps.'
+  #  truncate_timestamps_to_ms: 1000
+  #- note: 'New Relic adds a "prometheus_server" label to distinguish Prometheus servers, leading to extra labels in query results. These need to be stripped before comparisons.'
+  #- note: 'New Relic does not consistently include the "__name__" attribute in its responses.'
+  #  no_bug: true
+  #  drop_result_labels:
+  #    - prometheus_server
+  #    - __name__
+  #- note: 'New Relic omits the first resolution step in the output.'
+  #  ignore_first_step: true
+  #- note: 'New Relic stores metric counters as deltas, not cumulative values. New Relic will recognize these as guages by if "_cnt" is appended to the metric name.'
+  #  apply_query_substitution:
+  #    old: _total
+  #    new: _total_cnt
 
 test_cases:
   # Scalar literals.

--- a/promql-compliance-tester.yml
+++ b/promql-compliance-tester.yml
@@ -40,7 +40,6 @@ query_tweaks:
   # - note: 'New Relic is sometimes off by 1ms when parsing floating point start/end timestamps.'
   #   truncate_timestamps_to_ms: 1000
   # - note: 'New Relic adds a "prometheus_server" label to distinguish Prometheus servers, leading to extra labels in query results. These need to be stripped before comparisons.'
-  # - note: 'New Relic does not consistently include the "__name__" attribute in its responses.'
   #   no_bug: true
   #   drop_result_labels:
   #     - prometheus_server

--- a/promql-compliance-tester.yml
+++ b/promql-compliance-tester.yml
@@ -46,7 +46,7 @@ query_tweaks:
   #     - prometheus_server
   # - note: 'New Relic omits the first resolution step in the output.'
   #   ignore_first_step: true
-  # - note: 'New Relic stores metric counters as deltas, not cumulative values. New Relic will recognize these as guages by if "_cnt" is appended to the metric name.'
+  # - note: 'New Relic stores metric counters as deltas, not cumulative values. New Relic will recognize these as gauges by if "_cnt" is appended to the metric name.'
   #   query_string_replacements:
   #     _total: _total_cnt
 

--- a/promql-compliance-tester.yml
+++ b/promql-compliance-tester.yml
@@ -47,9 +47,8 @@ query_tweaks:
   #- note: 'New Relic omits the first resolution step in the output.'
   #  ignore_first_step: true
   #- note: 'New Relic stores metric counters as deltas, not cumulative values. New Relic will recognize these as guages by if "_cnt" is appended to the metric name.'
-  #  apply_query_substitution:
-  #    old: _total
-  #    new: _total_cnt
+  #  query_string_replacements:
+  #    _total: _total_cnt
 
 test_cases:
   # Scalar literals.

--- a/promql-compliance-tester.yml
+++ b/promql-compliance-tester.yml
@@ -45,14 +45,6 @@ query_tweaks:
   #     - prometheus_server
   # - note: 'New Relic omits the first resolution step in the output.'
   #   ignore_first_step: true
-  # - note: 'New Relic stores metric counters as deltas, not cumulative values. New Relic will recognize these as gauges by if "_cnt" is appended to the metric name.'
-  #   query_string_replacements:
-  #     remove: _total
-  #     replacement: _total_cnt
-  #     exemptions:
-  #       - delta
-  #       - rate
-  #       - increase
 
 test_cases:
   # Scalar literals.

--- a/promql-compliance-tester.yml
+++ b/promql-compliance-tester.yml
@@ -15,8 +15,9 @@ test_target_config:
   # query_url: 'http://localhost:20902'
   #
   # UNCOMMENT FOR NEW RELIC, replacing <insights_query_api_key>
-  # query_url: https://prometheus-api.newrelic.com
-  # x_query_key: <insights_query_api_key>
+  query_url: https://prometheus-api.newrelic.com
+  headers:
+    X-Query-Key: <insights_query_api_key>
 
 query_tweaks:
   # UNCOMMENT FOR CORTEX:
@@ -36,20 +37,20 @@ query_tweaks:
   #  align_timestamps_to_step: true
   #
   # UNCOMMENT FOR NEW RELIC:
-  #- note: 'New Relic is sometimes off by 1ms when parsing floating point start/end timestamps.'
-  #  truncate_timestamps_to_ms: 1000
-  #- note: 'New Relic adds a "prometheus_server" label to distinguish Prometheus servers, leading to extra labels in query results. These need to be stripped before comparisons.'
-  #- note: 'New Relic does not consistently include the "__name__" attribute in its responses.'
-  #  no_bug: true
-  #  drop_result_labels:
-  #    - prometheus_server
-  #    - __name__
-  #- note: 'New Relic omits the first resolution step in the output.'
-  #  ignore_first_step: true
-  #- note: 'New Relic stores metric counters as deltas, not cumulative values. New Relic will recognize these as guages by if "_cnt" is appended to the metric name.'
-  #  apply_query_substitution:
-  #    old: _total
-  #    new: _total_cnt
+  - note: 'New Relic is sometimes off by 1ms when parsing floating point start/end timestamps.'
+    truncate_timestamps_to_ms: 1000
+  - note: 'New Relic adds a "prometheus_server" label to distinguish Prometheus servers, leading to extra labels in query results. These need to be stripped before comparisons.'
+  - note: 'New Relic does not consistently include the "__name__" attribute in its responses.'
+    no_bug: true
+    drop_result_labels:
+      - prometheus_server
+      - __name__
+  - note: 'New Relic omits the first resolution step in the output.'
+    ignore_first_step: true
+  - note: 'New Relic stores metric counters as deltas, not cumulative values. New Relic will recognize these as guages by if "_cnt" is appended to the metric name.'
+    apply_query_substitution:
+      old: _total
+      new: _total_cnt
 
 test_cases:
   # Scalar literals.

--- a/promql-compliance-tester.yml
+++ b/promql-compliance-tester.yml
@@ -37,20 +37,19 @@ query_tweaks:
   #  align_timestamps_to_step: true
   #
   # UNCOMMENT FOR NEW RELIC:
-  - note: 'New Relic is sometimes off by 1ms when parsing floating point start/end timestamps.'
-    truncate_timestamps_to_ms: 1000
-  - note: 'New Relic adds a "prometheus_server" label to distinguish Prometheus servers, leading to extra labels in query results. These need to be stripped before comparisons.'
-  - note: 'New Relic does not consistently include the "__name__" attribute in its responses.'
-    no_bug: true
-    drop_result_labels:
-      - prometheus_server
-      - __name__
-  - note: 'New Relic omits the first resolution step in the output.'
-    ignore_first_step: true
-  - note: 'New Relic stores metric counters as deltas, not cumulative values. New Relic will recognize these as guages by if "_cnt" is appended to the metric name.'
-    apply_query_substitution:
-      old: _total
-      new: _total_cnt
+  #- note: 'New Relic is sometimes off by 1ms when parsing floating point start/end timestamps.'
+  #  truncate_timestamps_to_ms: 1000
+  #- note: 'New Relic adds a "prometheus_server" label to distinguish Prometheus servers, leading to extra labels in query results. These need to be stripped before comparisons.'
+  #- note: 'New Relic does not consistently include the "__name__" attribute in its responses.'
+  #  no_bug: true
+  #  drop_result_labels:
+  #    - prometheus_server
+  #- note: 'New Relic omits the first resolution step in the output.'
+  #  ignore_first_step: true
+  #- note: 'New Relic stores metric counters as deltas, not cumulative values. New Relic will recognize these as guages by if "_cnt" is appended to the metric name.'
+  #  apply_query_substitution:
+  #    old: _total
+  #    new: _total_cnt
 
 test_cases:
   # Scalar literals.

--- a/promql-compliance-tester.yml
+++ b/promql-compliance-tester.yml
@@ -15,9 +15,9 @@ test_target_config:
   # query_url: 'http://localhost:20902'
   #
   # UNCOMMENT FOR NEW RELIC, replacing <insights_query_api_key>
-  query_url: https://prometheus-api.newrelic.com
-  headers:
-    X-Query-Key: <insights_query_api_key>
+  # query_url: https://prometheus-api.newrelic.com
+  # headers:
+  #   X-Query-Key: <insights_query_api_key>
 
 query_tweaks:
   # UNCOMMENT FOR CORTEX:
@@ -37,18 +37,18 @@ query_tweaks:
   #  align_timestamps_to_step: true
   #
   # UNCOMMENT FOR NEW RELIC:
-  #- note: 'New Relic is sometimes off by 1ms when parsing floating point start/end timestamps.'
-  #  truncate_timestamps_to_ms: 1000
-  #- note: 'New Relic adds a "prometheus_server" label to distinguish Prometheus servers, leading to extra labels in query results. These need to be stripped before comparisons.'
-  #- note: 'New Relic does not consistently include the "__name__" attribute in its responses.'
-  #  no_bug: true
-  #  drop_result_labels:
-  #    - prometheus_server
-  #- note: 'New Relic omits the first resolution step in the output.'
-  #  ignore_first_step: true
-  #- note: 'New Relic stores metric counters as deltas, not cumulative values. New Relic will recognize these as guages by if "_cnt" is appended to the metric name.'
-  #  query_string_replacements:
-  #    _total: _total_cnt
+  # - note: 'New Relic is sometimes off by 1ms when parsing floating point start/end timestamps.'
+  #   truncate_timestamps_to_ms: 1000
+  # - note: 'New Relic adds a "prometheus_server" label to distinguish Prometheus servers, leading to extra labels in query results. These need to be stripped before comparisons.'
+  # - note: 'New Relic does not consistently include the "__name__" attribute in its responses.'
+  #   no_bug: true
+  #   drop_result_labels:
+  #     - prometheus_server
+  # - note: 'New Relic omits the first resolution step in the output.'
+  #   ignore_first_step: true
+  # - note: 'New Relic stores metric counters as deltas, not cumulative values. New Relic will recognize these as guages by if "_cnt" is appended to the metric name.'
+  #   query_string_replacements:
+  #     _total: _total_cnt
 
 test_cases:
   # Scalar literals.

--- a/promql-compliance-tester.yml
+++ b/promql-compliance-tester.yml
@@ -50,7 +50,8 @@ test_cases:
   # Scalar literals.
   - query: '42'
   - query: '1.234'
-  - query: '.123e-9'
+  - query: '.123'
+  - query: '1.23e-3'
   - query: '0x3d'
   - query: 'Inf'
   - query: '+Inf'

--- a/promql-compliance-tester.yml
+++ b/promql-compliance-tester.yml
@@ -47,7 +47,12 @@ query_tweaks:
   #   ignore_first_step: true
   # - note: 'New Relic stores metric counters as deltas, not cumulative values. New Relic will recognize these as gauges by if "_cnt" is appended to the metric name.'
   #   query_string_replacements:
-  #     _total: _total_cnt
+  #     remove: _total
+  #     replacement: _total_cnt
+  #     exemptions:
+  #       - delta
+  #       - rate
+  #       - increase
 
 test_cases:
   # Scalar literals.

--- a/testcases/expand.go
+++ b/testcases/expand.go
@@ -34,7 +34,6 @@ package testcases
 import (
 	"bytes"
 	"fmt"
-	"strings"
 	"text/template"
 	"time"
 
@@ -124,14 +123,6 @@ func applyQueryTweaks(tc *comparer.TestCase, tweaks []*config.QueryTweak) *compa
 		if t.AlignTimestampsToStep {
 			resTC.Start = resTC.Start.Truncate(resTC.Resolution)
 			resTC.End = resTC.End.Truncate(resTC.Resolution)
-		}
-		if len(t.QueryStringReplacements.Remove) > 0 {
-			for _, e := range t.QueryStringReplacements.Exemptions {
-				if strings.HasPrefix(resTC.Query, e) {
-					return &resTC
-				}
-			}
-			resTC.Query = strings.ReplaceAll(resTC.Query, t.QueryStringReplacements.Remove, t.QueryStringReplacements.Replacement)
 		}
 	}
 	return &resTC

--- a/testcases/expand.go
+++ b/testcases/expand.go
@@ -125,8 +125,13 @@ func applyQueryTweaks(tc *comparer.TestCase, tweaks []*config.QueryTweak) *compa
 			resTC.Start = resTC.Start.Truncate(resTC.Resolution)
 			resTC.End = resTC.End.Truncate(resTC.Resolution)
 		}
-		for oldStr, newStr := range t.QueryStringReplacements {
-			resTC.Query = strings.ReplaceAll(resTC.Query, oldStr, newStr)
+		if len(t.ApplyQuerySubstitution.Remove) > 0 {
+			for _, e := range t.ApplyQuerySubstitution.Exemptions {
+				if strings.HasPrefix(resTC.Query, e) {
+					return &resTC
+				}
+			}
+			resTC.Query = strings.ReplaceAll(resTC.Query, t.ApplyQuerySubstitution.Remove, t.ApplyQuerySubstitution.Replacement)
 		}
 	}
 	return &resTC

--- a/testcases/expand.go
+++ b/testcases/expand.go
@@ -125,13 +125,13 @@ func applyQueryTweaks(tc *comparer.TestCase, tweaks []*config.QueryTweak) *compa
 			resTC.Start = resTC.Start.Truncate(resTC.Resolution)
 			resTC.End = resTC.End.Truncate(resTC.Resolution)
 		}
-		if len(t.ApplyQuerySubstitution.Remove) > 0 {
-			for _, e := range t.ApplyQuerySubstitution.Exemptions {
+		if len(t.QueryStringReplacements.Remove) > 0 {
+			for _, e := range t.QueryStringReplacements.Exemptions {
 				if strings.HasPrefix(resTC.Query, e) {
 					return &resTC
 				}
 			}
-			resTC.Query = strings.ReplaceAll(resTC.Query, t.ApplyQuerySubstitution.Remove, t.ApplyQuerySubstitution.Replacement)
+			resTC.Query = strings.ReplaceAll(resTC.Query, t.QueryStringReplacements.Remove, t.QueryStringReplacements.Replacement)
 		}
 	}
 	return &resTC

--- a/testcases/expand.go
+++ b/testcases/expand.go
@@ -34,6 +34,7 @@ package testcases
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"text/template"
 	"time"
 
@@ -123,6 +124,9 @@ func applyQueryTweaks(tc *comparer.TestCase, tweaks []*config.QueryTweak) *compa
 		if t.AlignTimestampsToStep {
 			resTC.Start = resTC.Start.Truncate(resTC.Resolution)
 			resTC.End = resTC.End.Truncate(resTC.Resolution)
+		}
+		if (config.Substitution{}) != t.ApplyQuerySubstitution {
+			resTC.Query = strings.ReplaceAll(resTC.Query, t.ApplyQuerySubstitution.Old, t.ApplyQuerySubstitution.New)
 		}
 	}
 	return &resTC

--- a/testcases/expand.go
+++ b/testcases/expand.go
@@ -125,8 +125,8 @@ func applyQueryTweaks(tc *comparer.TestCase, tweaks []*config.QueryTweak) *compa
 			resTC.Start = resTC.Start.Truncate(resTC.Resolution)
 			resTC.End = resTC.End.Truncate(resTC.Resolution)
 		}
-		if (config.Substitution{}) != t.ApplyQuerySubstitution {
-			resTC.Query = strings.ReplaceAll(resTC.Query, t.ApplyQuerySubstitution.Old, t.ApplyQuerySubstitution.New)
+		for oldStr, newStr := range t.QueryStringReplacements {
+			resTC.Query = strings.ReplaceAll(resTC.Query, oldStr, newStr)
 		}
 	}
 	return &resTC


### PR DESCRIPTION
- Added X-Query-Key header support, which will allow running the tester directly against New Relics prometheus-api endpoint.
- Added ability to globally configure substitution in query strings, allowing the replacement of us to replace "_total" with "_total_cnt" in all configured queries at runtime.
- Added New Relic connection and query_tweak capabilities.

NOTE: The New Relic query_tweaks include ignore all "__name__" attributes in responses.  But, I hope to have that fixed on the New Relic side in the coming weeks.  That's why I've marked this as a draft.