### PR TITLE
Let user specify start time in config file for reproducible tests.

### DIFF
--- a/cmd/promql-compliance-tester/main.go
+++ b/cmd/promql-compliance-tester/main.go
@@ -97,11 +97,11 @@ func main() {
 		QueryTweaks: cfg.QueryTweaks,
 	}
 
-	end := getTime(cfg.Timing.EndTime, time.Now().UTC().Add(-2*time.Minute))
+	end := getTime(cfg.QueryTimeParameters.EndTime, time.Now().UTC().Add(-2*time.Minute))
 	start := end.Add(
-		-getNonZeroDuration(cfg.Timing.RangeInSeconds, 10*time.Minute))
+		-getNonZeroDuration(cfg.QueryTimeParameters.RangeInSeconds, 10*time.Minute))
 	resolution := getNonZeroDuration(
-		cfg.Timing.ResolutionInSeconds, 10*time.Second)
+		cfg.QueryTimeParameters.ResolutionInSeconds, 10*time.Second)
 	expandedTestCases := testcases.ExpandTestCases(cfg.TestCases, cfg.QueryTweaks, start, end, resolution)
 
 	progressBar := pb.StartNew(len(expandedTestCases))

--- a/config/config.go
+++ b/config/config.go
@@ -1,11 +1,10 @@
 package config
 
 import (
-	"io/ioutil"
-
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
+	"io/ioutil"
 )
 
 // Config models the main configuration file.
@@ -14,6 +13,13 @@ type Config struct {
 	TestTargetConfig      TargetConfig  `yaml:"test_target_config"`
 	QueryTweaks           []*QueryTweak `yaml:"query_tweaks"`
 	TestCases             []*TestCase   `yaml:"test_cases"`
+	Timing                Timing        `yaml:"timing"`
+}
+
+type Timing struct {
+	EndTime             string  `yaml:"end_time"`
+	RangeInSeconds      float64 `yaml:"range_in_seconds"`
+	ResolutionInSeconds float64 `yaml:"resolution_in_seconds"`
 }
 
 // TargetConfig represents the configuration of a single Prometheus API endpoint.

--- a/config/config.go
+++ b/config/config.go
@@ -1,22 +1,23 @@
 package config
 
 import (
+	"io/ioutil"
+
 	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
 )
 
 // Config models the main configuration file.
 type Config struct {
-	ReferenceTargetConfig TargetConfig  `yaml:"reference_target_config"`
-	TestTargetConfig      TargetConfig  `yaml:"test_target_config"`
-	QueryTweaks           []*QueryTweak `yaml:"query_tweaks"`
-	TestCases             []*TestCase   `yaml:"test_cases"`
-	Timing                Timing        `yaml:"timing"`
+	ReferenceTargetConfig TargetConfig        `yaml:"reference_target_config"`
+	TestTargetConfig      TargetConfig        `yaml:"test_target_config"`
+	QueryTweaks           []*QueryTweak       `yaml:"query_tweaks"`
+	TestCases             []*TestCase         `yaml:"test_cases"`
+	QueryTimeParameters   QueryTimeParameters `yaml:"query_time_parameters"`
 }
 
-type Timing struct {
+type QueryTimeParameters struct {
 	EndTime             string  `yaml:"end_time"`
 	RangeInSeconds      float64 `yaml:"range_in_seconds"`
 	ResolutionInSeconds float64 `yaml:"resolution_in_seconds"`


### PR DESCRIPTION
This PR allows tester to add a start time in the config file as seconds after 1970. When start time is present, the compliance tester always uses that start time instead of using 12 minutes before the present.  This feature enables reproducible test results.