### PR TITLE
Make float64 comparison configurable.

### DIFF
--- a/cmd/promql-compliance-tester/main.go
+++ b/cmd/promql-compliance-tester/main.go
@@ -79,7 +79,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error loading configuration file: %v", err)
 	}
-
 	refAPI, err := newPromAPI(cfg.ReferenceTargetConfig)
 	if err != nil {
 		log.Fatalf("Error creating reference API: %v", err)
@@ -89,11 +88,7 @@ func main() {
 		log.Fatalf("Error creating test API: %v", err)
 	}
 
-	comp := comparer.Comparer{
-		RefAPI:      refAPI,
-		TestAPI:     testAPI,
-		QueryTweaks: cfg.QueryTweaks,
-	}
+	comp := comparer.New(refAPI, testAPI, cfg.QueryTweaks)
 
 	// Expand all placeholder variations in the templated test cases.
 	end := time.Now().Add(-2 * time.Minute)

--- a/config/config.go
+++ b/config/config.go
@@ -27,12 +27,18 @@ type TargetConfig struct {
 
 // A QueryTweak restricts or modifies a query in certain ways that avoids certain systematic errors and/or later comparison problems.
 type QueryTweak struct {
-	Note                   string            `yaml:"note" json:"note"`
-	NoBug                  bool              `yaml:"no_bug,omitempty" json:"noBug,omitempty"`
-	TruncateTimestampsToMS int64             `yaml:"truncate_timestamps_to_ms" json:"truncateTimestampsToMS,omitempty"`
-	AlignTimestampsToStep  bool              `yaml:"align_timestamps_to_step" json:"alignTimestampsToStep,omitempty"`
-	DropResultLabels       []model.LabelName `yaml:"drop_result_labels" json:"dropResultLabels,omitempty"`
-	IgnoreFirstStep        bool              `yaml:"ignore_first_step" json:"ignoreFirstStep,omitempty"`
+	Note                   string                `yaml:"note" json:"note"`
+	NoBug                  bool                  `yaml:"no_bug,omitempty" json:"noBug,omitempty"`
+	TruncateTimestampsToMS int64                 `yaml:"truncate_timestamps_to_ms" json:"truncateTimestampsToMS,omitempty"`
+	AlignTimestampsToStep  bool                  `yaml:"align_timestamps_to_step" json:"alignTimestampsToStep,omitempty"`
+	DropResultLabels       []model.LabelName     `yaml:"drop_result_labels" json:"dropResultLabels,omitempty"`
+	IgnoreFirstStep        bool                  `yaml:"ignore_first_step" json:"ignoreFirstStep,omitempty"`
+	AdjustValueTolerance   *AdjustValueTolerance `yaml:"adjust_value_tolerance" json:"adjustValueTolerance,omitempty"`
+}
+
+type AdjustValueTolerance struct {
+	Fraction *float64 `yaml:"fraction" json:"fraction,omitempty"`
+	Margin   *float64 `yaml:"margin" json:"margin,omitempty"`
 }
 
 // TestCase represents a given query (pattern) to be tested.


### PR DESCRIPTION
We want to adjust the float comparison for our tests by changing the fraction and margin attributes.

Compute cmp.Options only once instead of for each test case as they don't
change.

Signed-off-by: Travis Keep <travisk@vmware.com>